### PR TITLE
Add float16 (f2) dtype support, bump spec to 0.5

### DIFF
--- a/vcf_zarr_spec.md
+++ b/vcf_zarr_spec.md
@@ -1,6 +1,6 @@
 # VCF Zarr specification
 
-***Version 0.4***
+***Version 0.5***
 
 This document is a technical specification for VCF Zarr, a means of encoding VCF data in chunked-columnar form using the Zarr format.
 
@@ -23,7 +23,7 @@ The VCF Zarr store contains the following mandatory attributes:
 
 | Key                | Value                                                                                |
 |--------------------|--------------------------------------------------------------------------------------|
-| `vcf_zarr_version` | `"0.4"`                                                                              |
+| `vcf_zarr_version` | `"0.5"`                                                                              |
 
 The following attributes are optional:
 
@@ -46,7 +46,7 @@ This document uses a shorthand notation to refer to Zarr data types (dtypes). Th
 |-----------|----------------------------------------------------------|-----------|
 | `bool`    | `\|b1`                                                   | Flag      |
 | `int`     | `<i1`, `<i2`, `<i4`, `<i8` or `>i1`, `>i2`, `>i4`, `>i8` | Integer   |
-| `float`   | `<f4`, `<f8` or `>f4`, `>f8`                             | Float     |
+| `float`   | `<f2`, `<f4`, `<f8` or `>f2`, `>f4`, `>f8`               | Float     |
 | `char`    | `\<U1` or `\>U1`                                         | Character |
 | `str`     | `\|O`                                                    | String    |
 
@@ -61,7 +61,7 @@ Missing values indicate the value is absent, and fill values are used to pad var
 | Dtype     | Missing                                            | Fill                                               |
 |-----------|----------------------------------------------------|----------------------------------------------------|
 | `int  `   | -1                                                 | -2                                                 |
-| `float  ` | NaN (0x7F800001 32-bit, 0x7FF0000000000001 64-bit) | NaN (0x7F800002 32-bit, 0x7FF0000000000002 64-bit) |
+| `float  ` | NaN (0x7C01 16-bit, 0x7F800001 32-bit, 0x7FF0000000000001 64-bit) | NaN (0x7C02 16-bit, 0x7F800002 32-bit, 0x7FF0000000000002 64-bit) |
 | `char`    | "."                                                | ""                                                 |
 | `str`     | "."                                                | ""                                                 |
 
@@ -191,6 +191,10 @@ Using the region index to perform an overlap query is a two-step process. First,
 For the previous example, the query 1:1-20000 matches the second and third rows of the region index, corresponding to chunk indexes 0 and 1. Applying the same overlap query to each of these chunks returns the third and fourth rows of the original dataset (1:14370 from the first chunk and 1:17330 from the second).
 
 ## Changes
+
+### Changes between VCF Zarr 0.4 and VCF Zarr 0.5
+
+* Add support for half-precision (`f2`) float dtype, with corresponding missing (0x7C01) and fill (0x7C02) NaN sentinel values.
 
 ### Changes between VCF Zarr 0.3 and VCF Zarr 0.4
 


### PR DESCRIPTION
Add half-precision float support to the dtype and missing/fill tables, with missing (0x7C01) and fill (0x7C02) NaN sentinels matching the existing float32/float64 conventions.

Closes #51